### PR TITLE
Feature/#5

### DIFF
--- a/src/main/java/com/skyhorsemanpower/payment/payment/application/PaymentService.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/application/PaymentService.java
@@ -18,5 +18,5 @@ public interface PaymentService {
 
 	List<PaymentListResponseDto> findPaymentList(String uuid);
 
-	boolean isPendingPayment(String auctionUuid);
+	boolean existPayment(String auctionUuid);
 }

--- a/src/main/java/com/skyhorsemanpower/payment/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/application/PaymentServiceImpl.java
@@ -188,12 +188,8 @@ public class PaymentServiceImpl implements PaymentService {
 
 	//결제 대기 여부 조회
 	@Override
-	public boolean isPendingPayment(String auctionUuid) {
+	public boolean existPayment(String auctionUuid) {
 		Optional<Payment> paymentOpt = this.paymentRepository.findByAuctionUuid(auctionUuid);
-
-		if (paymentOpt.isEmpty()) {
-			throw new CustomException(ResponseStatus.DOSE_NOT_EXIST_PAYMENT);
-		}
-		return paymentOpt.get().getPaymentStatus().equals(PaymentStatus.PENDING);
-	}
+        return paymentOpt.isPresent();
+    }
 }

--- a/src/main/java/com/skyhorsemanpower/payment/payment/presentation/AuthorizationPaymentController.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/presentation/AuthorizationPaymentController.java
@@ -12,7 +12,7 @@ import com.skyhorsemanpower.payment.payment.vo.PaymentAddRequestVo;
 import com.skyhorsemanpower.payment.payment.vo.PaymentAgreeRequestVo;
 import com.skyhorsemanpower.payment.payment.vo.PaymentDetailRequestVo;
 import com.skyhorsemanpower.payment.payment.vo.PaymentDetailResponseVo;
-import com.skyhorsemanpower.payment.payment.vo.PaymentIsPendingResponseVo;
+import com.skyhorsemanpower.payment.payment.vo.PaymentExistResponseVo;
 import com.skyhorsemanpower.payment.payment.vo.PaymentListResponseVo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -77,10 +77,10 @@ public class AuthorizationPaymentController {
         return new SuccessResponse<>(paymentListResponseVoList);
     }
 
-    @GetMapping("/is-pending")
-    @Operation(summary = "결제 대기 여부 조회", description = "결제 대기 여부를 조회합니다.")
-    public SuccessResponse<PaymentIsPendingResponseVo> isPending(@RequestParam String auctionUuid) {
+    @GetMapping("/existence")
+    @Operation(summary = "결제 내역 존재 여부 조회", description = "결제 내역이 존재하는지 조회합니다.")
+    public SuccessResponse<PaymentExistResponseVo> isPending(@RequestParam String auctionUuid) {
         return new SuccessResponse<>(
-            new PaymentIsPendingResponseVo(this.paymentService.isPendingPayment(auctionUuid)));
+            new PaymentExistResponseVo(this.paymentService.existPayment(auctionUuid)));
     }
 }

--- a/src/main/java/com/skyhorsemanpower/payment/payment/vo/PaymentExistResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/vo/PaymentExistResponseVo.java
@@ -1,0 +1,5 @@
+package com.skyhorsemanpower.payment.payment.vo;
+
+public record PaymentExistResponseVo(boolean exist) {
+
+}

--- a/src/main/java/com/skyhorsemanpower/payment/payment/vo/PaymentIsPendingResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/vo/PaymentIsPendingResponseVo.java
@@ -1,5 +1,0 @@
-package com.skyhorsemanpower.payment.payment.vo;
-
-public record PaymentIsPendingResponseVo(boolean isPending) {
-
-}

--- a/src/test/java/com/skyhorsemanpower/payment/PaymentServiceTest.java
+++ b/src/test/java/com/skyhorsemanpower/payment/PaymentServiceTest.java
@@ -1,6 +1,7 @@
 package com.skyhorsemanpower.payment;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.skyhorsemanpower.payment.common.GenerateRandom;
 import com.skyhorsemanpower.payment.common.PaymentStatus;
@@ -11,8 +12,7 @@ import com.skyhorsemanpower.payment.payment.infrastructure.PaymentRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class PaymentServiceTest {
@@ -35,10 +35,9 @@ public class PaymentServiceTest {
         this.paymentNumber = "9490-9464-2678-5492";
     }
 
-    @ParameterizedTest
-    @EnumSource(value = PaymentStatus.class)
-    @DisplayName("경매가 결제 대기 상태인지 조회한다.")
-    void paymentStatusIsPendingTest(PaymentStatus paymentStatus) {
+    @Test
+    @DisplayName("경매 결제 내역이 존재하면 true를 반환한다.")
+    void paymentExistTest() {
         //given
         Payment payment = Payment.builder()
             .id(1L)
@@ -48,7 +47,7 @@ public class PaymentServiceTest {
             .sellerUuid(sellerUuid)
             .paymentMethod("toss")
             .paymentNumber(paymentNumber)
-            .paymentStatus(paymentStatus)
+            .paymentStatus(PaymentStatus.PENDING)
             .build();
 
         Mockito.when(
@@ -56,9 +55,24 @@ public class PaymentServiceTest {
         ).thenReturn(Optional.of(payment));
 
         //when
-        boolean isPending = this.paymentService.isPendingPayment(auctionUuid);
+        boolean isPending = this.paymentService.existPayment(auctionUuid);
 
         //then
-        assertThat(isPending).isEqualTo(paymentStatus == PaymentStatus.PENDING);
+        assertTrue(isPending);
+    }
+
+    @Test
+    @DisplayName("경매 결제 내역이 존재하지 않으면 false를 반환한다.")
+    void paymentNotExistTest() {
+        //given
+        Mockito.when(
+            paymentRepository.findByAuctionUuid(auctionUuid)
+        ).thenReturn(Optional.empty());
+
+        //when
+        boolean isPending = this.paymentService.existPayment(auctionUuid);
+
+        //then
+        assertFalse(isPending);
     }
 }


### PR DESCRIPTION
- #5 
- 생각해보니 3명의 참가자 중 한명이라도 결제를 해야  결제 내역이 생성됩니다. 미리 결제 내역을 만들어 놓을 수 없습니다.
- 결제 대기 여부 조회를 결제 내역 존재 여부를 조회하도록 수정했습니다.