### PR TITLE
refactor: 아이엠포트 토큰 발급 테스트를 WebMvcTest로 진행

### DIFF
--- a/src/test/java/com/skyhorsemanpower/payment/IamportTest.java
+++ b/src/test/java/com/skyhorsemanpower/payment/IamportTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.skyhorsemanpower.payment.iamport.IamportTokenProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
-@SpringBootTest
+@WebMvcTest(IamportTokenProvider.class)
 public class IamportTest {
 
     @Autowired


### PR DESCRIPTION
github action에서 jar 빌드 시 테스트 코드를 수행하는데, 이때 `@SpringBootTest`는 데이터베이스 연결까지 해버립니다.
빌드 시 prod 프로파일 환경설정을 받으므로 ec2와 연결할 수 없어 테스트에 실패합니다.
`@WebMvcTest`는 웹계층만 테스트하기 때문에 데이터베이스까지 연결하지 않습니다.