### PR TITLE
Refactor/#59

### DIFF
--- a/src/main/java/com/skyhorsemanpower/payment/iamport/IamportService.java
+++ b/src/main/java/com/skyhorsemanpower/payment/iamport/IamportService.java
@@ -1,0 +1,8 @@
+package com.skyhorsemanpower.payment.iamport;
+
+import com.skyhorsemanpower.payment.iamport.dto.PaymentInfoDto;
+
+public interface IamportService {
+
+    PaymentInfoDto getPaymentInfo(String impUid);
+}

--- a/src/main/java/com/skyhorsemanpower/payment/iamport/IamportServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/payment/iamport/IamportServiceImpl.java
@@ -65,13 +65,13 @@ public class IamportServiceImpl implements IamportService {
 
         String payMethod = "etc";
         String payNumber = "etc";
-        if (bankCode != null && bankName != null) {
+        if (!bankCode.isNull() && !bankName.isNull()) {
             payMethod = bankName.asText();
             payNumber = bankCode.asText();
-        } else if (cardCode != null && cardName != null) {
+        } else if (!cardCode.isNull() && !cardName.isNull()) {
             payMethod = cardName.asText();
             payNumber = cardCode.asText();
-        } else if (vbankCode != null && vbankName != null) {
+        } else if (!vbankCode.isNull() && !vbankName.isNull()) {
             payMethod = vbankName.asText();
             payNumber = vbankCode.asText();
         }

--- a/src/main/java/com/skyhorsemanpower/payment/iamport/IamportServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/payment/iamport/IamportServiceImpl.java
@@ -1,0 +1,84 @@
+package com.skyhorsemanpower.payment.iamport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.skyhorsemanpower.payment.iamport.dto.PaymentInfoDto;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class IamportServiceImpl implements IamportService {
+
+    private static final String IAMPORT_PAYMENT_URL = "https://api.iamport.kr/payments/";
+
+    private final IamportTokenProvider iamportTokenProvider;
+
+    private String getIamportToken() {
+        return iamportTokenProvider.getIamportToken();
+    }
+
+    @Override
+    public PaymentInfoDto getPaymentInfo(String impUid) {
+        try {
+            String url = UriComponentsBuilder.fromHttpUrl(IAMPORT_PAYMENT_URL)
+                .pathSegment(impUid)
+                .toUriString();
+            String authorization = String.format("Bearer %s", getIamportToken());
+
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "application/json")
+                .header("Authorization", authorization)
+                .GET()
+                .build();
+
+            ObjectMapper mapper = new ObjectMapper();
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+            String responseBody = response.body();
+            JsonNode rootNode = mapper.readTree(responseBody);
+            JsonNode resNode = rootNode.get("response");
+            return parseIamportPaymentResponse(resNode);
+        } catch (InterruptedException | IOException | RuntimeException e) {
+            log.info("getPaymentInfo error: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private PaymentInfoDto parseIamportPaymentResponse(JsonNode resNode) {
+        JsonNode bankCode = resNode.get("bank_code");
+        JsonNode bankName = resNode.get("bank_name");
+        JsonNode cardCode = resNode.get("card_number");
+        JsonNode cardName = resNode.get("card_name");
+        JsonNode vbankCode = resNode.get("vcard_code");
+        JsonNode vbankName = resNode.get("vbank_name");
+
+        String payMethod = "etc";
+        String payNumber = "etc";
+        if (bankCode != null && bankName != null) {
+            payMethod = bankName.asText();
+            payNumber = bankCode.asText();
+        } else if (cardCode != null && cardName != null) {
+            payMethod = cardName.asText();
+            payNumber = cardCode.asText();
+        } else if (vbankCode != null && vbankName != null) {
+            payMethod = vbankName.asText();
+            payNumber = vbankCode.asText();
+        }
+        return PaymentInfoDto.builder()
+            .payMethod(payMethod)
+            .payNumber(payNumber)
+            .amount(resNode.get("amount").decimalValue())
+            .build();
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/payment/iamport/IamportTokenProvider.java
+++ b/src/main/java/com/skyhorsemanpower/payment/iamport/IamportTokenProvider.java
@@ -3,7 +3,6 @@ package com.skyhorsemanpower.payment.iamport;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.ext.ParamConverter.Lazy;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -21,7 +20,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class IamportTokenProvider {
 
-    private static final String IMPORT_TOKEN_URL = "https://api.iamport.kr/users/getToken";
+    private static final String IAMPORT_TOKEN_URL = "https://api.iamport.kr/users/getToken";
 
     @Value("${imp_key}")
     private String KEY;
@@ -33,26 +32,24 @@ public class IamportTokenProvider {
         Map<String, String> body = new HashMap<>();
         body.put("imp_key", KEY);
         body.put("imp_secret", SECRET);
-
         try {
             ObjectMapper mapper = new ObjectMapper();
             String jsonBody = mapper.writeValueAsString(body);
 
             HttpClient client = HttpClient.newHttpClient();
             HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(IMPORT_TOKEN_URL))
+                .uri(URI.create(IAMPORT_TOKEN_URL))
                 .header("Content-Type", "application/json")
                 .POST(BodyPublishers.ofString(jsonBody))
                 .build();
 
             HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
             String responseBody = response.body();
-            log.info("key: {}, secret: {}, responseBody: {}", KEY, SECRET, responseBody);
             JsonNode rootNode = mapper.readTree(responseBody);
             JsonNode resNode = rootNode.get("response");
             return resNode.get("access_token").asText();
         } catch (InterruptedException | IOException | RuntimeException e) {
-            log.info("getIamportToken error{}", e.getMessage());
+            log.info("getIamportToken error: {}", e.getMessage());
             return null;
         }
     }

--- a/src/main/java/com/skyhorsemanpower/payment/iamport/dto/PaymentInfoDto.java
+++ b/src/main/java/com/skyhorsemanpower/payment/iamport/dto/PaymentInfoDto.java
@@ -1,0 +1,25 @@
+package com.skyhorsemanpower.payment.iamport.dto;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PaymentInfoDto {
+
+    private String payMethod;
+    private String payNumber;
+    private BigDecimal amount;
+
+
+    @Builder
+    public PaymentInfoDto(String payMethod, String payNumber, BigDecimal amount) {
+        this.payMethod = payMethod;
+        this.payNumber = payNumber;
+        this.amount = amount;
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/payment/payment/domain/Payment.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/domain/Payment.java
@@ -32,6 +32,8 @@ public class Payment extends BaseTimeEntity {
     private Long id;
     @Column(name = "payment_uuid", nullable = false, unique = true, length = 18)
     private String paymentUuid;
+    @Column(name = "imp_uid", nullable = true, length = 20)
+    private String impUid;
     @Column(name = "auction_uuid", nullable = false, length = 23)
     private String auctionUuid;
     @Column(name = "member_uuid", nullable = false, length = 36)
@@ -51,12 +53,13 @@ public class Payment extends BaseTimeEntity {
     private LocalDateTime completionAt;
 
     @Builder
-    public Payment(Long id, String paymentUuid, String auctionUuid, String memberUuid,
-        String paymentMethod, String paymentNumber,
+    public Payment(Long id, String paymentUuid, String impUid,String auctionUuid,
+        String memberUuid, String paymentMethod, String paymentNumber,
         PaymentStatus paymentStatus,
         BigDecimal price, BigDecimal amountPaid, LocalDateTime completionAt) {
         this.id = id;
         this.paymentUuid = paymentUuid;
+        this.impUid = impUid;
         this.auctionUuid = auctionUuid;
         this.memberUuid = memberUuid;
         this.paymentMethod = paymentMethod;

--- a/src/main/java/com/skyhorsemanpower/payment/payment/dto/PaymentDetailResponseDto.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/dto/PaymentDetailResponseDto.java
@@ -18,6 +18,7 @@ import lombok.Setter;
 public class PaymentDetailResponseDto {
 
     private String paymentUuid;
+    private String impUid;
     private String auctionUuid;
     private String paymentMethod;
     private String paymentNumber;
@@ -32,6 +33,7 @@ public class PaymentDetailResponseDto {
     ) {
         return new PaymentDetailResponseVo(
             paymentDetailResponseDto.getPaymentUuid(),
+            paymentDetailResponseDto.getImpUid(),
             paymentDetailResponseDto.getAuctionUuid(),
             paymentDetailResponseDto.getPaymentMethod(),
             paymentDetailResponseDto.getPaymentNumber(),

--- a/src/main/java/com/skyhorsemanpower/payment/payment/dto/PaymentListResponseDto.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/dto/PaymentListResponseDto.java
@@ -18,6 +18,7 @@ import lombok.Setter;
 public class PaymentListResponseDto {
 
     private String paymentUuid;
+    private String impUid;
     private String auctionUuid;
     private String memberUuid;
     private String paymentMethod;
@@ -30,6 +31,7 @@ public class PaymentListResponseDto {
     public static PaymentListResponseVo dtoToVo(PaymentListResponseDto paymentListResponseDto) {
         return new PaymentListResponseVo(
             paymentListResponseDto.getPaymentUuid(),
+            paymentListResponseDto.getImpUid(),
             paymentListResponseDto.getAuctionUuid(),
             paymentListResponseDto.getPrice(),
             paymentListResponseDto.getPaymentStatus(),

--- a/src/main/java/com/skyhorsemanpower/payment/payment/vo/PaymentDetailResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/vo/PaymentDetailResponseVo.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 public class PaymentDetailResponseVo {
 
     private String paymentUuid;
+    private String impUid;
     private String auctionUuid;
     private String paymentMethod;
     private String paymentNumber;
@@ -20,6 +21,7 @@ public class PaymentDetailResponseVo {
 
     public PaymentDetailResponseVo(
         String paymentUuid,
+        String impUid,
         String auctionUuid,
         String paymentMethod,
         String paymentNumber,
@@ -29,6 +31,7 @@ public class PaymentDetailResponseVo {
         LocalDateTime createdAt,
         LocalDateTime completionAt) {
         this.paymentUuid = paymentUuid;
+        this.impUid = impUid;
         this.auctionUuid = auctionUuid;
         this.paymentMethod = paymentMethod;
         this.paymentNumber = paymentNumber;

--- a/src/main/java/com/skyhorsemanpower/payment/payment/vo/PaymentListResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/payment/payment/vo/PaymentListResponseVo.java
@@ -9,15 +9,18 @@ import lombok.Getter;
 public class PaymentListResponseVo {
 
     private String paymentUuid;
+    private String impUid;
     private String auctionUuid;
     private BigDecimal price;
     private PaymentStatus paymentStatus;
     private String paymentNumber;
     private LocalDateTime completionAt;
 
-    public PaymentListResponseVo(String paymentUuid, String auctionUuid, BigDecimal price,
+    public PaymentListResponseVo(String paymentUuid, String impUid, String auctionUuid,
+        BigDecimal price,
         PaymentStatus paymentStatus, String paymentNumber, LocalDateTime completionAt) {
         this.paymentUuid = paymentUuid;
+        this.impUid = impUid;
         this.auctionUuid = auctionUuid;
         this.price = price;
         this.paymentStatus = paymentStatus;

--- a/src/test/java/com/skyhorsemanpower/payment/IamportTest.java
+++ b/src/test/java/com/skyhorsemanpower/payment/IamportTest.java
@@ -2,7 +2,10 @@ package com.skyhorsemanpower.payment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.skyhorsemanpower.payment.iamport.IamportService;
+import com.skyhorsemanpower.payment.iamport.IamportServiceImpl;
 import com.skyhorsemanpower.payment.iamport.IamportTokenProvider;
+import com.skyhorsemanpower.payment.iamport.dto.PaymentInfoDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -18,6 +21,16 @@ public class IamportTest {
         String token = iamportTokenProvider.getIamportToken();
 
         assertThat(token).isNotNull();
+    }
+
+    @Test
+    void getIamportPaymentInfoTest() {
+        IamportService iamportService = new IamportServiceImpl(iamportTokenProvider);
+        PaymentInfoDto paymentInfoDto = iamportService.getPaymentInfo("imp_889504258470");
+
+        assertThat(paymentInfoDto.getAmount()).isNotNull();
+        assertThat(paymentInfoDto.getPayMethod()).isNotNull();
+        assertThat(paymentInfoDto.getPayNumber()).isNotNull();
     }
 
 }


### PR DESCRIPTION
- [x] #59 
- 클라이언트에서 `POST /api/v1/payment`를 호출했다는건 이미 결제 완료됐다는 의미로 받아들이고, 결제 정보만 저장합니다.

1. 아이엠포트 모듈을 이용해 결제하면 `imp_uid`를 받습니다. 이를 클라이언트로부터 받습니다.
2. 백엔드에서 아이엠포트에서 제공해주는 결제 내역 단건 조회 API를 호출합니다. 
3. 기존 결제 대기 내역에 imp_uid와 결제 방법, 결제코드(은행 코드 | 카드 번호 | 가상계좌 코드), 결제 완료 시간을 저장합니다.

- 아이엠포트 결제내역 단건 조회 시 토큰이 필요한데, 토큰 발급 받는 요청을 먼저 한 후에 결제내역 단건 조회를 요청합니다.
즉 매번 토큰을 발급하고 있습니다. 토큰 만료시간은 30분입니다.
- 30분마다 어떻게 자동으로 토큰을 발급받을지 의견을 구하고 싶습니다.